### PR TITLE
v0.2.0

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "VirgilSecurity/crypto-x" "3.2.1"
 github "VirgilSecurity/cryptoapi-x" "1.0.3"
-github "VirgilSecurity/keyknox-x" "0.2.0"
-github "VirgilSecurity/pythia-x" "0.3.2"
-github "VirgilSecurity/sdk-x" "5.4.1"
+github "VirgilSecurity/keyknox-x" "0.2.1"
+github "VirgilSecurity/pythia-x" "0.3.3"
+github "VirgilSecurity/sdk-x" "5.5.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 - multidevice support
 - manage users' Public Keys
 
-
 ## Installation
 
 Virgil E3Kit is provided as a set of frameworks. These frameworks are distributed via Carthage.  Also in this guide, you find one more package called VirgilCrypto (Virgil Crypto Library) that is used by the E3Kit to perform cryptographic operations.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://api.travis-ci.org/VirgilSecurity/e3kit-x.svg?branch=master)](https://travis-ci.com/VirgilSecurity/e3kit-x)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/VirgilE3Kit.svg)](https://cocoapods.org/pods/VirgilE3Kit)
-[![Platform](https://img.shields.io/cocoapods/p/VirgilE3Kit.svg?style=flat)](http://cocoadocs.org/docsets/VirgilE3Kit)
+[![Platform](https://img.shields.io/cocoapods/p/VirgilE3Kit.svg?style=flat)](https://cocoapods.org/pods/VirgilE3Kit)
 [![GitHub license](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://github.com/VirgilSecurity/virgil/blob/master/LICENSE)
 
 

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ let messageToEncrypt = "Hello, Bob!"
 // initialize E3Kit
 EThree.initialize(tokenCallback) { eThree, error in 
     // Authenticate user 
-    eThree!.bootstrap(password: password) { error in 
+    eThree!.bootstrap(password: password) { error in
         // Search user's publicKeys to encrypt for
-        eThree!.lookUpPublicKeys(of: ["Alice", "Den"]) { publicKeys, errors in 
+        eThree!.lookUpPublicKeys(of: ["Alice", "Den"]) { lookupResult, errors in 
             // encrypt text
-            let encryptedMessage = try! eThree.encrypt(messageToEncrypt, for: publicKeys)
+            let encryptedMessage = try! eThree.encrypt(messageToEncrypt, for: lookupResult)
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To integrate Virgil E3Kit into your Xcode project using CocoaPods, specify it in
 target '<Your Target Name>' do
 use_frameworks!
 
-pod 'VirgilE3Kit', '~> 0.1.1'
+pod 'VirgilE3Kit', '~> 0.2.0'
 end
 ```
 
@@ -64,7 +64,7 @@ $ brew install carthage
 To integrate VirgilE3Kit into your Xcode project using Carthage, create an empty file with name *Cartfile* in your project's root folder and add following lines to your *Cartfile*
 
 ```
-github "VirgilSecurity/e3kit-x" ~> 0.1.1
+github "VirgilSecurity/e3kit-x" ~> 0.2.0
 ```
 
 #### Linking against prebuilt binaries

--- a/Source/EThree.swift
+++ b/Source/EThree.swift
@@ -76,12 +76,12 @@ import VirgilCryptoApiImpl
     internal let cloudKeyManager: CloudKeyManager
     internal let authManager: AuthManager
 
-    internal init(identity: String, cardManager: CardManager) throws {
+    internal init(identity: String, cardManager: CardManager, storageParams: KeychainStorageParams? = nil) throws {
         self.identity = identity
         self.crypto = VirgilCrypto()
         self.cardManager = cardManager
 
-        let storageParams = try KeychainStorageParams.makeKeychainStorageParams()
+        let storageParams = try storageParams ?? KeychainStorageParams.makeKeychainStorageParams()
         let keychainStorage = KeychainStorage(storageParams: storageParams)
 
         self.localKeyManager = LocalKeyManager(identity: identity,

--- a/Source/PublicAPI/EThree+Bootstrap.swift
+++ b/Source/PublicAPI/EThree+Bootstrap.swift
@@ -45,8 +45,8 @@ extension EThree {
     ///   - tokenCallback: callback to get Virgil access token
     ///   - completion: completion handler, called with initialized EThree or corresponding Error
     @objc public static func initialize(tokenCallback: @escaping RenewJwtCallback,
-                                        completion: @escaping (EThree?, Error?) -> (),
-                                        storageParams: KeychainStorageParams? = nil) {
+                                        storageParams: KeychainStorageParams? = nil,
+                                        completion: @escaping (EThree?, Error?) -> ()) {
         let renewTokenCallback: CachingJwtProvider.RenewJwtCallback = { _, completion in
             tokenCallback(completion)
         }

--- a/Source/PublicAPI/EThree+Bootstrap.swift
+++ b/Source/PublicAPI/EThree+Bootstrap.swift
@@ -45,13 +45,14 @@ extension EThree {
     ///   - tokenCallback: callback to get Virgil access token
     ///   - completion: completion handler, called with initialized EThree or corresponding Error
     @objc public static func initialize(tokenCallback: @escaping RenewJwtCallback,
-                                        completion: @escaping (EThree?, Error?) -> ()) {
+                                        completion: @escaping (EThree?, Error?) -> (),
+                                        storageParams: KeychainStorageParams? = nil) {
         let renewTokenCallback: CachingJwtProvider.RenewJwtCallback = { _, completion in
             tokenCallback(completion)
         }
 
         let accessTokenProvider = CachingJwtProvider(renewTokenCallback: renewTokenCallback)
-        let tokenContext = TokenContext(service: "cards", operation: "")
+        let tokenContext = TokenContext(service: "cards", operation: "") 
         accessTokenProvider.getToken(with: tokenContext) { token, error in
             guard let identity = token?.identity(), error == nil else {
                 completion(nil, error)
@@ -68,7 +69,7 @@ extension EThree {
                                                cardVerifier: verifier)
                 let cardManager = CardManager(params: params)
 
-                let ethree = try EThree(identity: identity, cardManager: cardManager)
+                let ethree = try EThree(identity: identity, cardManager: cardManager, storageParams: storageParams)
                 completion(ethree, nil)
             } catch {
                 completion(nil, error)

--- a/Source/PublicAPI/EThree+Bootstrap.swift
+++ b/Source/PublicAPI/EThree+Bootstrap.swift
@@ -52,7 +52,7 @@ extension EThree {
         }
 
         let accessTokenProvider = CachingJwtProvider(renewTokenCallback: renewTokenCallback)
-        let tokenContext = TokenContext(service: "cards", operation: "") 
+        let tokenContext = TokenContext(service: "cards", operation: "")
         accessTokenProvider.getToken(with: tokenContext) { token, error in
             guard let identity = token?.identity(), error == nil else {
                 completion(nil, error)

--- a/Source/PublicAPI/EThree+Encryption.swift
+++ b/Source/PublicAPI/EThree+Encryption.swift
@@ -45,7 +45,7 @@ extension EThree {
     /// Note: Automatically includes self key to recipientsKeys.
     /// - Parameters:
     ///   - data: data to encrypt
-    ///   - recipientKeys: array with recipient PublicKeys to sign and encrypt with. Use nil to sign and encrypt for self.
+    ///   - recipientKeys: array with recipient PublicKeys to sign and encrypt with. Use nil to sign and encrypt for self
     /// - Returns: decrypted Data
     /// - Throws: corresponding error
     /// - Important: Requires a bootstrapped user
@@ -71,24 +71,19 @@ extension EThree {
     /// Note: Automatically includes self key to recipientsKeys.
     /// - Parameters:
     ///   - data: data to decrypt
-    ///   - senderKeys: array with senders PublicKeys to verify with. Use nil to decrypt and verify from self.
+    ///   - senderPublicKey: sender PublicKey to verify with. Use nil to decrypt and verify from self
     /// - Returns: decrypted Data
     /// - Throws: corresponding error
     /// - Important: Requires a bootstrapped user
-    @objc public func decrypt(data: Data, from senderKeys: [VirgilPublicKey]? = nil) throws -> Data {
-        if let senderKeys = senderKeys, senderKeys.isEmpty {
-            throw EThreeError.missingKeys
-        }
-        let senderKeys = senderKeys ?? []
-
+    @objc public func decrypt(data: Data, from senderPublicKey: VirgilPublicKey? = nil) throws -> Data {
         guard let selfKeyPair = self.localKeyManager.retrieveKeyPair() else {
             throw EThreeError.notBootstrapped
         }
 
-        let publicKeys = senderKeys + [selfKeyPair.publicKey]
+        let senderPublicKey = senderPublicKey ?? selfKeyPair.publicKey
 
         let decryptedData = try self.crypto.decryptThenVerify(data, with: selfKeyPair.privateKey,
-                                                              usingOneOf: publicKeys)
+                                                              using: senderPublicKey)
 
         return decryptedData
     }
@@ -99,7 +94,7 @@ extension EThree {
     /// Note: Automatically includes self key to recipientsKeys.
     /// - Parameters:
     ///   - text: String to encrypt
-    ///   - recipientKeys: array with recipient PublicKeys to sign and encrypt with. Use nil to sign and encrypt for self.
+    ///   - recipientKeys: array with recipient PublicKeys to sign and encrypt with. Use nil to sign and encrypt for self
     /// - Returns: encrypted base64String
     /// - Throws: corresponding error
     /// - Important: Requires a bootstrapped user
@@ -117,16 +112,16 @@ extension EThree {
     /// Note: Automatically includes self key to recipientsKeys.
     /// - Parameters:
     ///   - text: encrypted String
-    ///   - senderKeys: array with senders PublicKeys to verify with. Use nil to decrypt and verify from self.
+    ///   - senderPublicKey: sender PublicKey to verify with. Use nil to decrypt and verify from self.
     /// - Returns: decrypted String
     /// - Throws: corresponding error
     /// - Important: Requires a bootstrapped user
-    @objc public func decrypt(text: String, from senderKeys: [VirgilPublicKey]? = nil) throws -> String {
+    @objc public func decrypt(text: String, from senderPublicKey: VirgilPublicKey? = nil) throws -> String {
         guard let data = Data(base64Encoded: text) else {
             throw EThreeError.strToDataFailed
         }
 
-        let decryptedData = try self.decrypt(data: data, from: senderKeys)
+        let decryptedData = try self.decrypt(data: data, from: senderPublicKey)
 
         guard let decryptedString = String(data: decryptedData, encoding: .utf8) else {
             throw EThreeError.strFromDataFailed

--- a/Source/PublicAPI/EThree+Encryption.swift
+++ b/Source/PublicAPI/EThree+Encryption.swift
@@ -39,6 +39,9 @@ import VirgilCryptoApiImpl
 
 // MARK: - Extension with encrypt-decrypt operations
 extension EThree {
+    // Typealias for the valid result of lookupPublicKeys call
+    public typealias LookupResult = [String: VirgilPublicKey]
+
     /// Signs then encrypts data for group of users
     ///
     /// Important: Avoid key duplication
@@ -49,17 +52,23 @@ extension EThree {
     /// - Returns: decrypted Data
     /// - Throws: corresponding error
     /// - Important: Requires a bootstrapped user
-    @objc public func encrypt(data: Data, for recipientKeys: [VirgilPublicKey]? = nil) throws -> Data {
-        if let recipientKeys = recipientKeys, recipientKeys.isEmpty {
-            throw EThreeError.missingKeys
-        }
-        let recipientKeys = recipientKeys ?? []
-
+    @objc public func encrypt(data: Data, for recipientKeys: LookupResult? = nil) throws -> Data {
         guard let selfKeyPair = self.localKeyManager.retrieveKeyPair() else {
             throw EThreeError.notBootstrapped
         }
 
-        let publicKeys = recipientKeys + [selfKeyPair.publicKey]
+        var publicKeys: [VirgilPublicKey] = []
+
+        if let recipientKeys = recipientKeys {
+            guard !recipientKeys.isEmpty else {
+                throw EThreeError.missingKeys
+            }
+
+            publicKeys = publicKeys + recipientKeys.values
+        }
+
+        publicKeys = publicKeys + [selfKeyPair.publicKey]
+
         let encryptedData = try self.crypto.signThenEncrypt(data, with: selfKeyPair.privateKey, for: publicKeys)
 
         return encryptedData
@@ -98,7 +107,7 @@ extension EThree {
     /// - Returns: encrypted base64String
     /// - Throws: corresponding error
     /// - Important: Requires a bootstrapped user
-    @objc public func encrypt(text: String, for recipientKeys: [VirgilPublicKey]? = nil) throws -> String {
+    @objc public func encrypt(text: String, for recipientKeys: LookupResult? = nil) throws -> String {
         guard let data = text.data(using: .utf8) else {
             throw EThreeError.strToDataFailed
         }
@@ -135,16 +144,18 @@ extension EThree {
     /// Important: Avoid identities duplication
     /// - Parameters:
     ///   - identities: array of identities to search for
-    ///   - completion: completion handler, called with array with found Public Keys and array with Errors
+    ///   - completion: completion handler
+    ///   - lookupResult: dictionary with idenities as keys and found public keys as values
+    ///   - errors: array with Errors
     @objc public func lookupPublicKeys(of identities: [String],
-                                       completion: @escaping ([VirgilPublicKey], [Error]) -> ()) {
+                                       completion: @escaping (_ lookupResult: LookupResult, _ errors: [Error]) -> ()) {
         guard !identities.isEmpty else {
-            completion([], [EThreeError.missingIdentities])
+            completion([:], [EThreeError.missingIdentities])
             return
         }
 
         let group = DispatchGroup()
-        var result: [VirgilPublicKey] = []
+        var result: LookupResult = [:]
         var errors: [Error] = []
 
         for identity in identities {
@@ -163,7 +174,7 @@ extension EThree {
                     return
                 }
 
-                result.append(virgilPublicKey)
+                result[identity] = virgilPublicKey
 
                 defer { group.leave() }
             }

--- a/Source/PublicAPI/EThree+Encryption.swift
+++ b/Source/PublicAPI/EThree+Encryption.swift
@@ -65,7 +65,7 @@ extension EThree {
                 throw EThreeError.missingKeys
             }
 
-            publicKeys = publicKeys + recipientKeys.values
+            publicKeys += recipientKeys.values
         }
 
         let encryptedData = try self.crypto.signThenEncrypt(data, with: selfKeyPair.privateKey, for: publicKeys)

--- a/Source/PublicAPI/EThree+Encryption.swift
+++ b/Source/PublicAPI/EThree+Encryption.swift
@@ -48,7 +48,8 @@ extension EThree {
     /// Note: Automatically includes self key to recipientsKeys.
     /// - Parameters:
     ///   - data: data to encrypt
-    ///   - recipientKeys: array with recipient PublicKeys to sign and encrypt with. Use nil to sign and encrypt for self
+    ///   - recipientKeys: result of lookupPublicKeys call recipient PublicKeys to sign and encrypt with.
+    ///                    Use nil to sign and encrypt for self
     /// - Returns: decrypted Data
     /// - Throws: corresponding error
     /// - Important: Requires a bootstrapped user
@@ -103,7 +104,8 @@ extension EThree {
     /// Note: Automatically includes self key to recipientsKeys.
     /// - Parameters:
     ///   - text: String to encrypt
-    ///   - recipientKeys: array with recipient PublicKeys to sign and encrypt with. Use nil to sign and encrypt for self
+    ///   - recipientKeys: result of lookupPublicKeys call recipient PublicKeys to sign and encrypt with.
+    ///                    Use nil to sign and encrypt for self
     /// - Returns: encrypted base64String
     /// - Throws: corresponding error
     /// - Important: Requires a bootstrapped user

--- a/Source/PublicAPI/EThree+Encryption.swift
+++ b/Source/PublicAPI/EThree+Encryption.swift
@@ -147,8 +147,8 @@ extension EThree {
     /// - Parameters:
     ///   - identities: array of identities to search for
     ///   - completion: completion handler
-    ///   - lookupResult: dictionary with idenities as keys and found public keys as values
-    ///   - errors: array with Errors
+    ///     - lookupResult: dictionary with idenities as keys and found public keys as values
+    ///     - errors: array with Errors
     @objc public func lookupPublicKeys(of identities: [String],
                                        completion: @escaping (_ lookupResult: LookupResult, _ errors: [Error]) -> ()) {
         guard !identities.isEmpty else {

--- a/Source/PublicAPI/EThree+Encryption.swift
+++ b/Source/PublicAPI/EThree+Encryption.swift
@@ -58,7 +58,7 @@ extension EThree {
             throw EThreeError.notBootstrapped
         }
 
-        var publicKeys: [VirgilPublicKey] = []
+        var publicKeys = [selfKeyPair.publicKey]
 
         if let recipientKeys = recipientKeys {
             guard !recipientKeys.isEmpty else {
@@ -67,8 +67,6 @@ extension EThree {
 
             publicKeys = publicKeys + recipientKeys.values
         }
-
-        publicKeys = publicKeys + [selfKeyPair.publicKey]
 
         let encryptedData = try self.crypto.signThenEncrypt(data, with: selfKeyPair.privateKey, for: publicKeys)
 

--- a/Tests/VTE001_EncryptionTests.m
+++ b/Tests/VTE001_EncryptionTests.m
@@ -81,7 +81,7 @@ static const NSTimeInterval timeout = 20.;
         NSString *token = [self.utils getTokenStringWithIdentity:identity error:&error];
 
         completionHandler(token, error);
-    } completion:^(VTEEThree *eThree, NSError *error) {
+    } storageParams:nil completion:^(VTEEThree *eThree, NSError *error) {
         XCTAssert(eThree != nil && error == nil);
         self.eThree = eThree;
 
@@ -157,7 +157,7 @@ static const NSTimeInterval timeout = 20.;
             NSString *token = [self.utils getTokenStringWithIdentity:identity error:&error];
 
             completionHandler(token, error);
-        } completion:^(VTEEThree *eThree2, NSError *error) {
+        } storageParams:nil completion:^(VTEEThree *eThree2, NSError *error) {
             XCTAssert(eThree2 != nil && error == nil);
 
             [eThree2 bootstrapWithPassword:nil completion:^(NSError *error) {

--- a/Tests/VTE001_EncryptionTests.m
+++ b/Tests/VTE001_EncryptionTests.m
@@ -175,7 +175,7 @@ static const NSTimeInterval timeout = 20.;
                     VSMVirgilKeyPair *keyPair = [self.crypto generateKeyPairAndReturnError:&err];
                     XCTAssert(err == nil);
 
-                    NSString *decrypted = [eThree2 decryptWithText:encrypted from:@[keyPair.publicKey] error:&err];
+                    NSString *decrypted = [eThree2 decryptWithText:encrypted from:keyPair.publicKey error:&err];
                     XCTAssert(err != nil && decrypted == nil);
 
                     [eThree2 lookupPublicKeysOf:@[eThree1.identity] completion:^(NSArray<VSMVirgilPublicKey *> *foundPublicKeys, NSArray<NSError *> *errors) {
@@ -183,7 +183,7 @@ static const NSTimeInterval timeout = 20.;
                         XCTAssert(foundPublicKeys.firstObject != nil);
 
                         NSError *err;
-                        NSString *decrypted = [eThree2 decryptWithText:encrypted from:foundPublicKeys error:&err];
+                        NSString *decrypted = [eThree2 decryptWithText:encrypted from:foundPublicKeys.firstObject error:&err];
                         XCTAssert(err == nil);
                         XCTAssert([decrypted isEqualToString:plainText]);
 
@@ -220,29 +220,6 @@ static const NSTimeInterval timeout = 20.;
 }
 
 - (void)test05 {
-    XCTestExpectation *ex = [self expectationWithDescription:@"Decrypt with empty array of keys should throw error"];
-
-    [self.eThree bootstrapWithPassword:nil completion:^(NSError *error) {
-        XCTAssert(error == nil);
-
-        NSError *err;
-        VSMVirgilKeyPair *keyPair = [self.crypto generateKeyPairAndReturnError:&err];
-        NSString *encrypted = [self.eThree encryptWithText:@"plaintext" for:@[keyPair.publicKey] error:&err];
-        XCTAssert(error == nil);
-
-        NSString *decrypted = [self.eThree decryptWithText:encrypted from:@[] error:&err];
-        XCTAssert(err.code == VTEEThreeErrorMissingKeys && decrypted == nil);
-
-        [ex fulfill];
-    }];
-
-    [self waitForExpectationsWithTimeout:timeout handler:^(NSError *error) {
-        if (error != nil)
-            XCTFail(@"Expectation failed: %@", error);
-    }];
-}
-
-- (void)test06 {
     XCTestExpectation *ex = [self expectationWithDescription:@"Should decrypt self encrypted text"];
 
     [self.eThree bootstrapWithPassword:nil completion:^(NSError *error) {
@@ -267,7 +244,7 @@ static const NSTimeInterval timeout = 20.;
     }];
 }
 
-- (void)test07 {
+- (void)test06 {
     XCTestExpectation *ex = [self expectationWithDescription:@"Should throw error if decrypted text is not verified"];
 
     [self.eThree bootstrapWithPassword:nil completion:^(NSError *error) {
@@ -290,7 +267,7 @@ static const NSTimeInterval timeout = 20.;
             NSString *encryptedString = [encryptedData base64EncodedStringWithOptions:0];
             XCTAssert(encryptedString != nil);
 
-            NSString *decrypted = [self.eThree decryptWithText:encryptedString from:@[keyPair.publicKey] error:&err];
+            NSString *decrypted = [self.eThree decryptWithText:encryptedString from:keyPair.publicKey error:&err];
             XCTAssert(err != nil && decrypted == nil);
 
             [ex fulfill];
@@ -303,7 +280,7 @@ static const NSTimeInterval timeout = 20.;
     }];
 }
 
-- (void)test08 {
+- (void)test07 {
     NSError *error;
     [self.keychainStorage deleteEntryWithName:self.eThree.identity error: nil];
 
@@ -316,12 +293,12 @@ static const NSTimeInterval timeout = 20.;
 
     error = nil;
 
-    NSString *decrypted = [self.eThree decryptWithText:@"" from:@[keyPair.publicKey] error:&error];
+    NSString *decrypted = [self.eThree decryptWithText:@"" from:keyPair.publicKey error:&error];
     XCTAssert(error.code == VTEEThreeErrorNotBootstrapped);
     XCTAssert(decrypted == nil);
 }
 
-- (void)test09 {
+- (void)test08 {
     NSError *error;
     [self.keychainStorage deleteEntryWithName:self.eThree.identity error: nil];
 

--- a/Tests/VTE002_AuthenticationTests.m
+++ b/Tests/VTE002_AuthenticationTests.m
@@ -84,7 +84,7 @@ static const NSTimeInterval timeout = 20.;
         NSString *token = [self.utils getTokenStringWithIdentity:identity error:&error];
 
         completionHandler(token, error);
-    } completion:^(VTEEThree *eThree, NSError *error) {
+    } storageParams:nil completion:^(VTEEThree *eThree, NSError *error) {
         XCTAssert(eThree != nil && error == nil);
         self.eThree = eThree;
 

--- a/Tests/VTE003_KeyBackupTests.m
+++ b/Tests/VTE003_KeyBackupTests.m
@@ -84,7 +84,7 @@ static const NSTimeInterval timeout = 20.;
         NSString *token = [self.utils getTokenStringWithIdentity:identity error:&error];
 
         completionHandler(token, error);
-    } completion:^(VTEEThree *eThree, NSError *error) {
+    } storageParams:nil completion:^(VTEEThree *eThree, NSError *error) {
         XCTAssert(eThree != nil && error == nil);
         self.eThree = eThree;
 

--- a/Tests/VTETestUtils.m
+++ b/Tests/VTETestUtils.m
@@ -117,7 +117,7 @@
 }
 
 -(void)setUpSyncKeyStorageWithPassword:(NSString * __nonnull)password identity:(NSString * __nonnull)identity completionHandler:(void(^)(VSKSyncKeyStorage * _Nonnull, NSError * _Nonnull))completionHandler {
-    VSSCachingJwtProvider *provider = [[VSSCachingJwtProvider alloc] initWithRenewTokenCallback:^(VSSTokenContext *tokenContext, void(^completionHandler)(NSString *, NSError *)) {
+    VSSCachingJwtProvider *provider = [[VSSCachingJwtProvider alloc] initWithInitialJwt:nil renewTokenCallback:^(VSSTokenContext *tokenContext, void(^completionHandler)(NSString *, NSError *)) {
         NSError *error;
         NSString *token = [self getTokenStringWithIdentity:identity error:&error];
 

--- a/VirgilE3Kit.podspec
+++ b/VirgilE3Kit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                       	= "VirgilE3Kit"
-  s.version                   	= "0.1.1"
+  s.version                   	= "0.2.0"
   s.license      		= { :type => "BSD", :file => "LICENSE" }
   s.summary      		= "Vigil E3Kit for Apple devices and languages"
   s.homepage     		= "https://github.com/VirgilSecurity/e3kit-x/"

--- a/VirgilE3Kit/Info.plist
+++ b/VirgilE3Kit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.1</string>
+	<string>0.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>


### PR DESCRIPTION
- decrypt methods take one public key to verify message with
- lookupPublicKeys returns dictionary with identities as keys and found public keys as values
- encrypt methods take lookupResult instead of public keys
- added optional KeychainStorageParams parameter to initialize