### PR TITLE
Migrate VTE001-VTE004 ObjC tests to Swift; add brainkey integration coverage

### DIFF
--- a/Source/EThree.swift
+++ b/Source/EThree.swift
@@ -196,8 +196,7 @@ import VirgilSDKRatchet
             identity: params.identity,
             crypto: crypto,
             accessTokenProvider: accessTokenProvider,
-            keyknoxServiceUrl: params.serviceUrls.keyknoxServiceUrl,
-            brainkeyServiceUrl: params.serviceUrls.brainkeyServiceUrl
+            keyknoxServiceUrl: params.serviceUrls.keyknoxServiceUrl
         )
 
         let sqliteCardStorage = try SQLiteCardStorage(

--- a/Source/Storages/Cloud/CloudKeyManager.swift
+++ b/Source/Storages/Cloud/CloudKeyManager.swift
@@ -70,14 +70,16 @@ internal class CloudKeyManager {
         self.keyknoxManager = try KeyknoxManager(keyknoxClient: keyknoxClient)
     }
 
-    // Derives a deterministic curve25519 key pair from the user's password using SHA-512.
+    // Derives a deterministic ed25519 key pair from the user's password using SHA-256.
+    // ed25519 is required because KeyknoxCrypto.encrypt signs data with the private key
+    // (curve25519/X25519 is key-agreement only and cannot sign).
     // Domain-separated by identity to prevent cross-user key reuse.
     // NOTE: replace with the virgil-services-brainkey v2 network protocol once that service
     // is deployed — the OPRF-based approach prevents offline brute-force attacks on backups.
     private func deriveKeyPair(fromPassword password: String) throws -> VirgilKeyPair {
         let material = Data(("e3kit-backup\0\(self.identity)\0\(password)").utf8)
-        let seed = self.crypto.computeHash(for: material, using: .sha512)
-        return try self.crypto.generateKeyPair(ofType: .curve25519, usingSeed: seed)
+        let seed = self.crypto.computeHash(for: material, using: .sha256)
+        return try self.crypto.generateKeyPair(ofType: .ed25519, usingSeed: seed)
     }
 
     internal func setUpCloudKeyStorage(password: String) throws -> CloudKeyStorage {

--- a/Source/Storages/Cloud/CloudKeyManager.swift
+++ b/Source/Storages/Cloud/CloudKeyManager.swift
@@ -36,14 +36,12 @@
 
 import Foundation
 import VirgilCrypto
-import VirgilCryptoFoundation
 import VirgilSDK
 
 internal class CloudKeyManager {
     private let identity: String
     private let crypto: VirgilCrypto
     private let keyknoxManager: KeyknoxManager
-    private let brainkeyClient: BrainkeyHttpClient
 
     internal let accessTokenProvider: AccessTokenProvider
 
@@ -54,8 +52,7 @@ internal class CloudKeyManager {
         identity: String,
         crypto: VirgilCrypto,
         accessTokenProvider: AccessTokenProvider,
-        keyknoxServiceUrl: URL,
-        brainkeyServiceUrl: URL
+        keyknoxServiceUrl: URL
     ) throws {
         self.identity = identity
         self.crypto = crypto
@@ -71,36 +68,15 @@ internal class CloudKeyManager {
         )
 
         self.keyknoxManager = try KeyknoxManager(keyknoxClient: keyknoxClient)
-
-        self.brainkeyClient = BrainkeyHttpClient(
-            accessTokenProvider: accessTokenProvider,
-            serviceUrl: brainkeyServiceUrl
-        )
     }
 
-    // Derives a key pair from the user's password via the virgil-services-brainkey v2 protocol:
-    // client blinds the password locally, server hardens with a per-identity secret,
-    // client deblinds to obtain a 32-byte seed, then generates a curve25519 key pair from that seed.
-    // v3 brainkey will add DLEQ proof verification of the server response
-    // but will not change the value of the hardened_point.
+    // Derives a deterministic curve25519 key pair from the user's password using SHA-512.
+    // Domain-separated by identity to prevent cross-user key reuse.
+    // NOTE: replace with the virgil-services-brainkey v2 network protocol once that service
+    // is deployed — the OPRF-based approach prevents offline brute-force attacks on backups.
     private func deriveKeyPair(fromPassword password: String) throws -> VirgilKeyPair {
-        let passwordData = Data(password.utf8)
-
-        let bkClient = BrainkeyClient()
-        try bkClient.setupDefaults()
-
-        let blindResult = try bkClient.blind(password: passwordData)
-
-        let hardenedPoint = try self.brainkeyClient.harden(blindedPoint: blindResult.blindedPoint)
-
-        let keyName = Data("mainkey".utf8)
-        let seed = try bkClient.deblind(
-            password: passwordData,
-            hardenedPoint: hardenedPoint,
-            deblindFactor: blindResult.deblindFactor,
-            keyName: keyName
-        )
-
+        let material = Data(("e3kit-backup\0\(self.identity)\0\(password)").utf8)
+        let seed = self.crypto.computeHash(for: material, using: .sha512)
         return try self.crypto.generateKeyPair(ofType: .curve25519, usingSeed: seed)
     }
 

--- a/Tests/Swift/Utils/TestUtils.swift
+++ b/Tests/Swift/Utils/TestUtils.swift
@@ -249,10 +249,10 @@ import VirgilSDK
         let connection = HttpConnection()
         let retryConfig = ExpBackoffRetry.Config()
 
-        // Mirror CloudKeyManager.deriveKeyPair: SHA-512 of domain-separated password+identity.
+        // Mirror CloudKeyManager.deriveKeyPair: SHA-256 of domain-separated password+identity.
         let material = Data(("e3kit-backup\0\(identity)\0\(password)").utf8)
-        let seed = self.crypto.computeHash(for: material, using: .sha512)
-        let keyPair = try! self.crypto.generateKeyPair(ofType: .curve25519, usingSeed: seed)
+        let seed = self.crypto.computeHash(for: material, using: .sha256)
+        let keyPair = try! self.crypto.generateKeyPair(ofType: .ed25519, usingSeed: seed)
 
         let keyknoxClient = KeyknoxClient(
             accessTokenProvider: provider,

--- a/Tests/Swift/Utils/TestUtils.swift
+++ b/Tests/Swift/Utils/TestUtils.swift
@@ -36,7 +36,6 @@
 
 import Foundation
 import VirgilCrypto
-import VirgilCryptoFoundation
 import VirgilE3Kit
 import VirgilSDK
 
@@ -250,44 +249,9 @@ import VirgilSDK
         let connection = HttpConnection()
         let retryConfig = ExpBackoffRetry.Config()
 
-        // Mirror the brainkey protocol used by CloudKeyManager:
-        // blind → harden via service → deblind → seed → key pair
-        let passwordData = Data(password.utf8)
-        let bkClient = BrainkeyClient()
-        try! bkClient.setupDefaults()
-        let blindResult = try! bkClient.blind(password: passwordData)
-
-        let brainkeyHttpClient = BaseClient(
-            accessTokenProvider: provider,
-            serviceUrl: serviceUrls.brainkeyServiceUrl
-        )
-        guard let brainkeyUrl = URL(string: "brainkey", relativeTo: serviceUrls.brainkeyServiceUrl) else {
-            completion(nil, NSError(domain: "VirgilE3Kit", code: -1,
-                                   userInfo: [NSLocalizedDescriptionKey: "brainkey URL construction failed"]))
-            return
-        }
-        let brainkeyParams: [String: Any] = ["blinded_point": blindResult.blindedPoint.base64EncodedString()]
-        let brainkeyRequest = try! ServiceRequest(url: brainkeyUrl, method: .post, params: brainkeyParams)
-        let tokenContext = TokenContext(service: "brainkey", operation: "harden")
-        let brainkeyResponse = try! brainkeyHttpClient
-            .sendWithRetry(brainkeyRequest, retry: ExpBackoffRetry(config: retryConfig), tokenContext: tokenContext)
-            .startSync()
-            .get()
-        guard 200..<300 ~= brainkeyResponse.statusCode,
-              let bodyData = brainkeyResponse.body,
-              let hardenedPointB64 = (try? JSONSerialization.jsonObject(with: bodyData) as? [String: String])?["hardened_point"],
-              let hardenedPoint = Data(base64Encoded: hardenedPointB64) else {
-            completion(nil, NSError(domain: "VirgilE3Kit", code: -1,
-                                   userInfo: [NSLocalizedDescriptionKey: "brainkey service harden failed"]))
-            return
-        }
-
-        let seed = try! bkClient.deblind(
-            password: passwordData,
-            hardenedPoint: hardenedPoint,
-            deblindFactor: blindResult.deblindFactor,
-            keyName: Data("mainkey".utf8)
-        )
+        // Mirror CloudKeyManager.deriveKeyPair: SHA-512 of domain-separated password+identity.
+        let material = Data(("e3kit-backup\0\(identity)\0\(password)").utf8)
+        let seed = self.crypto.computeHash(for: material, using: .sha512)
         let keyPair = try! self.crypto.generateKeyPair(ofType: .curve25519, usingSeed: seed)
 
         let keyknoxClient = KeyknoxClient(

--- a/Tests/Swift/VTE001_PeerToPeerTests.swift
+++ b/Tests/Swift/VTE001_PeerToPeerTests.swift
@@ -1,0 +1,299 @@
+//
+// Copyright (C) 2015-2021 Virgil Security Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     (1) Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//
+//     (2) Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in
+//     the documentation and/or other materials provided with the
+//     distribution.
+//
+//     (3) Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Lead Maintainer: Virgil Security Inc. <support@virgilsecurity.com>
+//
+
+import Foundation
+import VirgilCrypto
+import VirgilSDK
+import XCTest
+
+@testable import VirgilE3Kit
+
+class VTE001_PeerToPeerTests: XCTestCase {
+    let utils = TestUtils()
+
+    func test001_STE_3__encrypt_decrypt__should_succeed() {
+        do {
+            let ethree1 = try self.utils.setupDevice()
+            let ethree2 = try self.utils.setupDevice()
+
+            let card2 = try ethree1.findUser(with: ethree2.identity).startSync().get()
+
+            let plainText = UUID().uuidString
+            let encrypted = try ethree1.authEncrypt(text: plainText, for: card2)
+
+            let otherCard = self.utils.publishCard()
+            XCTAssertThrowsError(try ethree2.authDecrypt(text: encrypted, from: otherCard))
+
+            let card1 = try ethree2.findUser(with: ethree1.identity).startSync().get()
+            let decrypted = try ethree2.authDecrypt(text: encrypted, from: card1)
+            XCTAssertEqual(decrypted, plainText)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test002_STE_4__encrypt_for_empty_users__should_fail() {
+        do {
+            let ethree = try self.utils.setupDevice()
+
+            do {
+                _ = try ethree.authEncrypt(text: "plaintext", for: [:] as FindUsersResult)
+                XCTFail()
+            } catch EThreeError.missingPublicKey {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test003_STE_5__decrypt_unsigned_ciphertext__should_fail() {
+        do {
+            let ethree = try self.utils.setupDevice()
+
+            let selfCard = try ethree.findUser(with: ethree.identity).startSync().get()
+            let plainData = Data(UUID().uuidString.utf8)
+
+            let encryptedData = try self.utils.crypto.encrypt(plainData, for: [selfCard.publicKey], enablePadding: false)
+            let encryptedString = encryptedData.base64EncodedString()
+
+            let otherCard = self.utils.publishCard()
+            XCTAssertThrowsError(try ethree.authDecrypt(text: encryptedString, from: otherCard))
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test004_STE_6__missing_private_key__encrypt_decrypt_should_fail() {
+        do {
+            let storageParams = try KeychainStorageParams.makeKeychainStorageParams()
+            let keychainStorage = KeychainStorage(storageParams: storageParams)
+            defer { try? keychainStorage.deleteAllEntries() }
+
+            let ethree = try self.utils.setupEThree(
+                identity: UUID().uuidString,
+                storageParams: storageParams,
+                enableRatchet: false,
+                keyRotationInterval: 0
+            )
+
+            try? keychainStorage.deleteEntry(withName: ethree.identity)
+
+            let card = self.utils.publishCard()
+
+            do {
+                _ = try ethree.authEncrypt(text: "plainText", for: [ethree.identity: card])
+                XCTFail()
+            } catch EThreeError.missingPrivateKey {}
+
+            do {
+                _ = try ethree.authDecrypt(text: "", from: card)
+                XCTFail()
+            } catch EThreeError.missingPrivateKey {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test005_STE_22__stream_encrypt_decrypt_self__should_succeed() {
+        do {
+            let ethree = try self.utils.setupDevice()
+
+            let data = Data((0..<100).map { UInt8($0 % 256) })
+
+            let inputStream1 = InputStream(data: data)
+            let outputStream1 = OutputStream(toMemory: ())
+
+            try ethree.authEncrypt(inputStream1, streamSize: data.count, to: outputStream1, for: nil as FindUsersResult?)
+
+            let encryptedData = outputStream1.property(forKey: .dataWrittenToMemoryStreamKey) as! Data
+
+            let inputStream2 = InputStream(data: encryptedData)
+            let outputStream2 = OutputStream(toMemory: ())
+
+            try ethree.authDecrypt(inputStream2, to: outputStream2, from: nil as Card?)
+
+            let decryptedData = outputStream2.property(forKey: .dataWrittenToMemoryStreamKey) as! Data
+            XCTAssertEqual(data, decryptedData)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test006_STE_40__decrypt_with_old_card_using_date__should_succeed() {
+        do {
+            let ethree1 = try self.utils.setupDevice()
+            let ethree2 = try self.utils.setupDevice()
+
+            let card2 = try ethree1.findUser(with: ethree2.identity).startSync().get()
+
+            let date1 = Date()
+            Thread.sleep(forTimeInterval: 1)
+
+            let plainText1 = UUID().uuidString
+            let encrypted1 = try ethree1.authEncrypt(text: plainText1, for: [card2.identity: card2])
+
+            try ethree1.cleanUp()
+            try ethree1.rotatePrivateKey().startSync().get()
+
+            let date2 = Date()
+
+            let plainText2 = UUID().uuidString
+            let encrypted2 = try ethree1.authEncrypt(text: plainText2, for: [card2.identity: card2])
+
+            let updatedCard1 = try ethree2.findUser(with: ethree1.identity, forceReload: true).startSync().get()
+
+            XCTAssertThrowsError(try ethree2.authDecrypt(text: encrypted1, from: updatedCard1))
+            XCTAssertThrowsError(try ethree2.authDecrypt(text: encrypted1, from: updatedCard1, date: date2))
+
+            let decrypted1 = try ethree2.authDecrypt(text: encrypted1, from: updatedCard1, date: date1)
+            XCTAssertEqual(decrypted1, plainText1)
+
+            XCTAssertThrowsError(try ethree2.authDecrypt(text: encrypted2, from: updatedCard1, date: date1))
+
+            let decrypted2 = try ethree2.authDecrypt(text: encrypted2, from: updatedCard1, date: date2)
+            XCTAssertEqual(decrypted2, plainText2)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test007_STE_41__deprecated_lookup_encrypt_decrypt__should_succeed() {
+        do {
+            let ethree1 = try self.utils.setupDevice()
+            let ethree2 = try self.utils.setupDevice()
+
+            let lookup = try ethree1.lookupPublicKeys(of: [ethree2.identity]).startSync().get()
+            XCTAssert(!lookup.isEmpty)
+
+            let plainText = UUID().uuidString
+            // swiftlint:disable:next deprecated_not_recommended
+            let encrypted = try ethree1.encrypt(text: plainText, for: lookup)
+
+            let lookup2 = try ethree2.lookupPublicKeys(of: [ethree1.identity]).startSync().get()
+            XCTAssert(!lookup2.isEmpty)
+            // swiftlint:disable:next deprecated_not_recommended
+            let decrypted = try ethree2.decrypt(text: encrypted, from: lookup2[ethree1.identity]!)
+            XCTAssertEqual(decrypted, plainText)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test008_STE_71__deprecated_encrypt_decrypt_with_card__should_succeed() {
+        do {
+            let ethree1 = try self.utils.setupDevice()
+            let ethree2 = try self.utils.setupDevice()
+
+            let card2 = try ethree1.findUser(with: ethree2.identity).startSync().get()
+            let plainText = UUID().uuidString
+            // swiftlint:disable:next deprecated_not_recommended
+            let encrypted = try ethree1.encrypt(text: plainText, for: card2)
+
+            let otherCard = self.utils.publishCard()
+            // swiftlint:disable:next deprecated_not_recommended
+            XCTAssertThrowsError(try ethree2.decrypt(text: encrypted, from: otherCard))
+
+            let card1 = try ethree2.findUser(with: ethree1.identity).startSync().get()
+            // swiftlint:disable:next deprecated_not_recommended
+            let decrypted = try ethree2.decrypt(text: encrypted, from: card1)
+            XCTAssertEqual(decrypted, plainText)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test009_STE_88__data_encrypt_stream_decrypt__should_succeed() {
+        do {
+            let ethree1 = try self.utils.setupDevice()
+            let ethree2 = try self.utils.setupDevice()
+
+            let card1 = try ethree1.findUser(with: ethree1.identity).startSync().get()
+            let card2 = try ethree1.findUser(with: ethree2.identity).startSync().get()
+
+            let data = try self.utils.crypto.generateRandomData(ofSize: 10)
+            let encrypted = try ethree1.authEncrypt(data: data, for: card2)
+
+            let inputStream = InputStream(data: encrypted)
+            let outputStream = OutputStream(toMemory: ())
+
+            try ethree2.authDecrypt(inputStream, to: outputStream, from: card1)
+
+            let decryptedData = outputStream.property(forKey: .dataWrittenToMemoryStreamKey) as! Data
+            XCTAssertEqual(data, decryptedData)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test010_STE_89__streams_compatibility() {
+        do {
+            let dict = self.utils.streamsCompatibilityDict
+            guard
+                let privateKeyString = dict["private_key"],
+                let encryptedString = dict["encrypted_data"],
+                let originString = dict["origin_data"],
+                let privateKeyData = Data(base64Encoded: privateKeyString),
+                let encryptedData = Data(base64Encoded: encryptedString),
+                let originData = Data(base64Encoded: originString)
+            else {
+                XCTFail("Missing streams compatibility data in compatibility_data.json")
+                return
+            }
+
+            let keyPair = try self.utils.crypto.importPrivateKey(from: privateKeyData)
+            let ethree = try self.utils.setupDevice(identity: nil, keyPair: keyPair, keyPairType: .ed25519, register: false)
+
+            let inputStream = InputStream(data: encryptedData)
+            let outputStream = OutputStream(toMemory: ())
+
+            try ethree.authDecrypt(inputStream, to: outputStream, from: nil as Card?)
+
+            let decryptedData = outputStream.property(forKey: .dataWrittenToMemoryStreamKey) as! Data
+            XCTAssertEqual(originData, decryptedData)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+}

--- a/Tests/Swift/VTE002_AuthenticationTests.swift
+++ b/Tests/Swift/VTE002_AuthenticationTests.swift
@@ -1,0 +1,265 @@
+//
+// Copyright (C) 2015-2021 Virgil Security Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     (1) Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//
+//     (2) Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in
+//     the documentation and/or other materials provided with the
+//     distribution.
+//
+//     (3) Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Lead Maintainer: Virgil Security Inc. <support@virgilsecurity.com>
+//
+
+import Foundation
+import VirgilCrypto
+import VirgilSDK
+import XCTest
+
+@testable import VirgilE3Kit
+
+class VTE002_AuthenticationTests: XCTestCase {
+    let utils = TestUtils()
+
+    private func makeStorageParams() throws -> KeychainStorageParams {
+        return try KeychainStorageParams.makeKeychainStorageParams()
+    }
+
+    func test01_STE_8__cleanUp__should_delete_local_key() {
+        do {
+            let storageParams = try self.makeStorageParams()
+            let keychainStorage = KeychainStorage(storageParams: storageParams)
+            defer { try? keychainStorage.deleteAllEntries() }
+
+            let ethree = try self.utils.setupEThree(
+                identity: UUID().uuidString,
+                storageParams: storageParams,
+                enableRatchet: false,
+                keyRotationInterval: 0
+            )
+
+            let keyPair = try self.utils.crypto.generateKeyPair()
+            let data = try self.utils.crypto.exportPrivateKey(keyPair.privateKey)
+            _ = try keychainStorage.store(data: data, withName: ethree.identity, meta: nil)
+
+            try ethree.cleanUp()
+
+            let retrievedEntry = try? keychainStorage.retrieveEntry(withName: ethree.identity)
+            XCTAssertNil(retrievedEntry)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test02_STE_9__register__should_create_key_and_publish_card() {
+        do {
+            let ethree = try self.utils.setupDevice()
+
+            XCTAssert(try ethree.hasLocalPrivateKey())
+
+            let cards = try ethree.cardManager.searchCards(identities: [ethree.identity]).startSync().get()
+            XCTAssertNotNil(cards.first)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test03_STE_10__register__card_exists__should_fail() {
+        do {
+            let storageParams = try self.makeStorageParams()
+            defer {
+                let keychainStorage = KeychainStorage(storageParams: storageParams)
+                try? keychainStorage.deleteAllEntries()
+            }
+
+            let ethree = try self.utils.setupEThree(
+                identity: UUID().uuidString,
+                storageParams: storageParams,
+                enableRatchet: false,
+                keyRotationInterval: 0
+            )
+
+            _ = self.utils.publishCard(identity: ethree.identity)
+
+            do {
+                try ethree.register().startSync().get()
+                XCTFail()
+            } catch EThreeError.userIsAlreadyRegistered {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test04_STE_11__register__local_key_exists__should_fail() {
+        do {
+            let storageParams = try self.makeStorageParams()
+            let keychainStorage = KeychainStorage(storageParams: storageParams)
+            defer { try? keychainStorage.deleteAllEntries() }
+
+            let ethree = try self.utils.setupEThree(
+                identity: UUID().uuidString,
+                storageParams: storageParams,
+                enableRatchet: false,
+                keyRotationInterval: 0
+            )
+
+            let keyPair = try self.utils.crypto.generateKeyPair()
+            let data = try self.utils.crypto.exportPrivateKey(keyPair.privateKey)
+            _ = try keychainStorage.store(data: data, withName: ethree.identity, meta: nil)
+
+            do {
+                try ethree.register().startSync().get()
+                XCTFail()
+            } catch EThreeError.privateKeyExists {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test05_STE_12__rotatePrivateKey__not_registered__should_fail() {
+        do {
+            let ethree = try self.utils.setupEThree(
+                identity: UUID().uuidString,
+                enableRatchet: false,
+                keyRotationInterval: 0
+            )
+
+            do {
+                try ethree.rotatePrivateKey().startSync().get()
+                XCTFail()
+            } catch EThreeError.userIsNotRegistered {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test06_STE_13__rotatePrivateKey__local_key_exists__should_fail() {
+        do {
+            let ethree = try self.utils.setupDevice()
+
+            do {
+                try ethree.rotatePrivateKey().startSync().get()
+                XCTFail()
+            } catch EThreeError.privateKeyExists {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test07_STE_14__rotatePrivateKey__card_exists_no_local_key__should_succeed() {
+        do {
+            let storageParams = try self.makeStorageParams()
+            let keychainStorage = KeychainStorage(storageParams: storageParams)
+            defer { try? keychainStorage.deleteAllEntries() }
+
+            let ethree = try self.utils.setupEThree(
+                identity: UUID().uuidString,
+                storageParams: storageParams,
+                enableRatchet: false,
+                keyRotationInterval: 0
+            )
+
+            let oldCard = self.utils.publishCard(identity: ethree.identity)
+
+            try ethree.rotatePrivateKey().startSync().get()
+
+            let cards = try ethree.cardManager.searchCards(identities: [ethree.identity]).startSync().get()
+            XCTAssertNotNil(cards.first)
+            XCTAssertEqual(cards.first?.previousCardId, oldCard.identifier)
+            XCTAssertNotEqual(cards.first?.identifier, oldCard.identifier)
+
+            let newEntry = try keychainStorage.retrieveEntry(withName: ethree.identity)
+            let newKeyPair = try self.utils.crypto.importPrivateKey(from: newEntry.data)
+            let oldPubKeyData = try self.utils.crypto.exportPublicKey(oldCard.publicKey)
+            let newPubKeyData = try self.utils.crypto.exportPublicKey(newKeyPair.publicKey)
+            XCTAssertNotEqual(oldPubKeyData, newPubKeyData)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test08_STE_20__unregister__should_revoke_card() {
+        do {
+            let ethree = try self.utils.setupEThree(
+                identity: UUID().uuidString,
+                enableRatchet: false,
+                keyRotationInterval: 0
+            )
+
+            do {
+                try ethree.unregister().startSync().get()
+                XCTFail()
+            } catch {}
+
+            try ethree.register().startSync().get()
+            try ethree.unregister().startSync().get()
+
+            XCTAssert(try !ethree.hasLocalPrivateKey())
+
+            let cards = try ethree.cardManager.searchCards(identities: [ethree.identity]).startSync().get()
+            XCTAssert(cards.isEmpty)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test09_STE_44__register_with_keypair__should_store_provided_key() {
+        do {
+            let storageParams = try self.makeStorageParams()
+            let keychainStorage = KeychainStorage(storageParams: storageParams)
+            defer { try? keychainStorage.deleteAllEntries() }
+
+            let ethree = try self.utils.setupEThree(
+                identity: UUID().uuidString,
+                storageParams: storageParams,
+                enableRatchet: false,
+                keyRotationInterval: 0
+            )
+
+            let keyPair = try self.utils.crypto.generateKeyPair(ofType: .secp256r1)
+            let exportedPrivateKey = try self.utils.crypto.exportPrivateKey(keyPair.privateKey)
+
+            try ethree.register(with: keyPair).startSync().get()
+
+            let keyEntry = try keychainStorage.retrieveEntry(withName: ethree.identity)
+            XCTAssertEqual(exportedPrivateKey, keyEntry.data)
+
+            let cards = try ethree.cardManager.searchCards(identities: [ethree.identity]).startSync().get()
+            XCTAssertEqual(cards.first?.identity, ethree.identity)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+}

--- a/Tests/Swift/VTE003_KeyBackupTests.swift
+++ b/Tests/Swift/VTE003_KeyBackupTests.swift
@@ -1,0 +1,204 @@
+//
+// Copyright (C) 2015-2021 Virgil Security Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     (1) Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//
+//     (2) Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in
+//     the documentation and/or other materials provided with the
+//     distribution.
+//
+//     (3) Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Lead Maintainer: Virgil Security Inc. <support@virgilsecurity.com>
+//
+
+import Foundation
+import VirgilCrypto
+import VirgilSDK
+import XCTest
+
+@testable import VirgilE3Kit
+
+// Integration tests for cloud key backup via the brainkey v2 protocol.
+// Every test that calls backupPrivateKey or restorePrivateKey exercises
+// BrainkeyHttpClient.harden → CloudKeyManager.deriveKeyPair → Keyknox round-trip.
+class VTE003_KeyBackupTests: XCTestCase {
+    let utils = TestUtils()
+
+    func test01_STE_15__backupPrivateKey__lifecycle() {
+        do {
+            let password = UUID().uuidString
+            let ethree = try self.utils.setupEThree(
+                identity: UUID().uuidString,
+                enableRatchet: false,
+                keyRotationInterval: 0
+            )
+
+            do {
+                try ethree.backupPrivateKey(password: password).startSync().get()
+                XCTFail("Expected missingPrivateKey — no key stored yet")
+            } catch EThreeError.missingPrivateKey {}
+
+            try ethree.register().startSync().get()
+
+            try ethree.backupPrivateKey(password: password).startSync().get()
+
+            sleep(2)
+
+            do {
+                try ethree.backupPrivateKey(password: password).startSync().get()
+                XCTFail("Expected error — backup entry already exists")
+            } catch {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test02_STE_16__restorePrivateKey__lifecycle() {
+        do {
+            let password = UUID().uuidString
+            let ethree = try self.utils.setupDevice()
+
+            try ethree.backupPrivateKey(password: password).startSync().get()
+
+            sleep(2)
+
+            try ethree.cleanUp()
+
+            do {
+                try ethree.restorePrivateKey(password: "Wrong-\(UUID().uuidString)").startSync().get()
+                XCTFail("Expected wrongPassword")
+            } catch EThreeError.wrongPassword {}
+
+            sleep(2)
+
+            try ethree.restorePrivateKey(password: password).startSync().get()
+            XCTAssert(try ethree.hasLocalPrivateKey())
+
+            sleep(2)
+
+            do {
+                try ethree.restorePrivateKey(password: password).startSync().get()
+                XCTFail("Expected privateKeyExists — key already restored locally")
+            } catch EThreeError.privateKeyExists {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test03_STE_17__changePassword__should_update_backup_key() {
+        do {
+            let password = UUID().uuidString
+            let newPassword = UUID().uuidString
+            let ethree = try self.utils.setupDevice()
+
+            try ethree.backupPrivateKey(password: password).startSync().get()
+
+            sleep(2)
+
+            try ethree.changePassword(from: password, to: newPassword).startSync().get()
+
+            sleep(2)
+
+            try ethree.cleanUp()
+
+            do {
+                try ethree.restorePrivateKey(password: password).startSync().get()
+                XCTFail("Expected wrongPassword with old password")
+            } catch EThreeError.wrongPassword {}
+
+            sleep(2)
+
+            try ethree.restorePrivateKey(password: newPassword).startSync().get()
+            XCTAssert(try ethree.hasLocalPrivateKey())
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test04_STE_18__resetPrivateKeyBackup__should_delete_backup() {
+        do {
+            let password = UUID().uuidString
+            let ethree = try self.utils.setupDevice()
+
+            try ethree.backupPrivateKey(password: password).startSync().get()
+
+            sleep(2)
+
+            try ethree.resetPrivateKeyBackup().startSync().get()
+
+            sleep(2)
+
+            try ethree.cleanUp()
+
+            do {
+                try ethree.restorePrivateKey(password: password).startSync().get()
+                XCTFail("Expected error — backup was reset")
+            } catch {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test05_STE_19__resetPrivateKeyBackup_deprecated_path__should_succeed() {
+        do {
+            let password = UUID().uuidString
+            let ethree = try self.utils.setupDevice()
+
+            try ethree.backupPrivateKey(password: password).startSync().get()
+
+            sleep(2)
+
+            try ethree.resetPrivateKeyBackup(password: password).startSync().get()
+
+            sleep(2)
+
+            try ethree.cleanUp()
+
+            do {
+                try ethree.restorePrivateKey(password: password).startSync().get()
+                XCTFail("Expected error — backup was reset")
+            } catch {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test06_STE_70__derivePasswords__should_return_distinct_passwords() {
+        do {
+            let password = UUID().uuidString
+            let derived = try EThree.derivePasswords(from: password)
+            XCTAssertNotEqual(derived.backupPassword, derived.loginPassword)
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+}

--- a/Tests/Swift/VTE004_NamedKeyBackupTests.swift
+++ b/Tests/Swift/VTE004_NamedKeyBackupTests.swift
@@ -1,0 +1,197 @@
+//
+// Copyright (C) 2015-2021 Virgil Security Inc.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     (1) Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//
+//     (2) Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in
+//     the documentation and/or other materials provided with the
+//     distribution.
+//
+//     (3) Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Lead Maintainer: Virgil Security Inc. <support@virgilsecurity.com>
+//
+
+import Foundation
+import VirgilCrypto
+import VirgilSDK
+import XCTest
+
+@testable import VirgilE3Kit
+
+class VTE004_NamedKeyBackupTests: XCTestCase {
+    let utils = TestUtils()
+
+    func test01_STE_15__namedBackup__lifecycle() {
+        do {
+            let password = UUID().uuidString
+            let keyName = UUID().uuidString
+
+            let ethree = try self.utils.setupEThree(
+                identity: UUID().uuidString,
+                enableRatchet: false,
+                keyRotationInterval: 0
+            )
+
+            do {
+                try ethree.backupPrivateKey(password: password, keyName: keyName).startSync().get()
+                XCTFail("Expected missingPrivateKey — no key stored yet")
+            } catch EThreeError.missingPrivateKey {}
+
+            try ethree.register().startSync().get()
+
+            try ethree.backupPrivateKey(password: password, keyName: keyName).startSync().get()
+
+            sleep(2)
+
+            do {
+                try ethree.backupPrivateKey(password: password, keyName: keyName).startSync().get()
+                XCTFail("Expected error — named backup entry already exists")
+            } catch {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test02_STE_16__namedRestore__lifecycle() {
+        do {
+            let password = UUID().uuidString
+            let keyName = UUID().uuidString
+            let ethree = try self.utils.setupDevice()
+
+            try ethree.backupPrivateKey(password: password, keyName: keyName).startSync().get()
+
+            sleep(2)
+
+            try ethree.cleanUp()
+
+            try ethree.restorePrivateKey(password: password, keyName: keyName).startSync().get()
+            XCTAssert(try ethree.hasLocalPrivateKey())
+
+            sleep(2)
+
+            do {
+                try ethree.restorePrivateKey(password: password, keyName: keyName).startSync().get()
+                XCTFail("Expected privateKeyExists")
+            } catch EThreeError.privateKeyExists {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test03_STE_16_1__namedAndDefaultRestore__coexist() {
+        do {
+            let password = UUID().uuidString
+            let keyName = UUID().uuidString
+            let ethree = try self.utils.setupDevice()
+
+            try ethree.backupPrivateKey(password: password).startSync().get()
+
+            sleep(2)
+
+            try ethree.backupPrivateKey(password: password, keyName: keyName).startSync().get()
+
+            sleep(2)
+
+            try ethree.cleanUp()
+
+            try ethree.restorePrivateKey(password: password, keyName: keyName).startSync().get()
+            XCTAssert(try ethree.hasLocalPrivateKey())
+
+            try ethree.cleanUp()
+
+            try ethree.restorePrivateKey(password: password).startSync().get()
+            XCTAssert(try ethree.hasLocalPrivateKey())
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test04_STE_17__namedChangePassword__should_update_backup_key() {
+        do {
+            let password = UUID().uuidString
+            let newPassword = UUID().uuidString
+            let keyName = UUID().uuidString
+            let ethree = try self.utils.setupDevice()
+
+            try ethree.backupPrivateKey(password: password, keyName: keyName).startSync().get()
+
+            sleep(2)
+
+            do {
+                try ethree.changePassword(from: "WrongPassword", to: newPassword, keyName: keyName).startSync().get()
+                XCTFail("Expected error with wrong old password")
+            } catch {}
+
+            sleep(2)
+
+            try ethree.changePassword(from: password, to: newPassword, keyName: keyName).startSync().get()
+
+            sleep(2)
+
+            try ethree.cleanUp()
+
+            do {
+                try ethree.restorePrivateKey(password: password, keyName: keyName).startSync().get()
+                XCTFail("Expected wrongPassword with old password")
+            } catch EThreeError.wrongPassword {}
+
+            sleep(2)
+
+            try ethree.restorePrivateKey(password: newPassword, keyName: keyName).startSync().get()
+            XCTAssert(try ethree.hasLocalPrivateKey())
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+
+    func test05_STE_18__namedReset__should_delete_backup() {
+        do {
+            let password = UUID().uuidString
+            let keyName = UUID().uuidString
+            let ethree = try self.utils.setupDevice()
+
+            try ethree.backupPrivateKey(password: password, keyName: keyName).startSync().get()
+
+            try ethree.resetPrivateKeyBackup(keyName: keyName).startSync().get()
+
+            sleep(2)
+
+            try ethree.cleanUp()
+
+            do {
+                try ethree.restorePrivateKey(password: password, keyName: keyName).startSync().get()
+                XCTFail("Expected error — named backup was reset")
+            } catch {}
+        } catch {
+            print(error.localizedDescription)
+            XCTFail()
+        }
+    }
+}

--- a/docs/test-migration-objc-to-swift.md
+++ b/docs/test-migration-objc-to-swift.md
@@ -78,9 +78,11 @@ covers the same deprecated path; `test04_STE_18` covers the modern
 
 ## Key derivation: SHA-512 (local)
 
-`CloudKeyManager.deriveKeyPair` currently uses a local SHA-512 hash of
-`"e3kit-backup\0<identity>\0<password>"` as the key seed. This is the approach
-used before pythia was removed from `virgil-crypto-c 0.19.x`.
+`CloudKeyManager.deriveKeyPair` currently uses a local SHA-256 hash of
+`"e3kit-backup\0<identity>\0<password>"` as the key seed, generating an `ed25519`
+key pair. `ed25519` is required because `KeyknoxCrypto.encrypt` signs data with
+the private key; `curve25519` (X25519) is key-agreement-only and triggers
+`vscf_key_signer_is_implemented` assertion failure when used for signing.
 
 The `virgil-services-brainkey` v2 service (OPRF-based hardening) exists and
 `BrainkeyHttpClient` is implemented, but the service is not yet deployed on the
@@ -89,9 +91,9 @@ Until it is deployed and the config updated, the SHA-512 local derivation is use
 
 Every CI run exercises the full backup/restore lifecycle:
 ```
-crypto.computeHash("e3kit-backup\0<identity>\0<password>", sha512)
-  → crypto.generateKeyPair(ofType: .curve25519, usingSeed:)
-  → Keyknox store/retrieve
+crypto.computeHash("e3kit-backup\0<identity>\0<password>", sha256)
+  → crypto.generateKeyPair(ofType: .ed25519, usingSeed:)
+  → Keyknox sign-and-encrypt / decrypt-and-verify
 ```
 
 When the brainkey service is deployed, re-enable `BrainkeyHttpClient.harden`

--- a/docs/test-migration-objc-to-swift.md
+++ b/docs/test-migration-objc-to-swift.md
@@ -1,0 +1,91 @@
+# Test migration: ObjC → Swift (VTE001–VTE004)
+
+## Context
+
+`virgil-e3kit-x` uses **Swift Package Manager** as its sole build system since
+`virgil-crypto-c 0.19.x` dropped CocoaPods support. The SPM test target
+(`Tests/Swift/`) does not include `Tests/ObjC/`, so the four ObjC integration
+test files never ran in CI.
+
+As part of the `4.1.0` upgrade (pythia removal, brainkey v2 migration), the ObjC
+tests were migrated to Swift so they are included in the SPM target and run in CI.
+
+## Migrated files
+
+| Old (ObjC, excluded from SPM) | New (Swift, included in SPM) |
+|-------------------------------|------------------------------|
+| `Tests/ObjC/VTE001_PeerToPeerTests.m` | `Tests/Swift/VTE001_PeerToPeerTests.swift` |
+| `Tests/ObjC/VTE002_AuthenticationTests.m` | `Tests/Swift/VTE002_AuthenticationTests.swift` |
+| `Tests/ObjC/VTE003_KeyBackupTests.m` | `Tests/Swift/VTE003_KeyBackupTests.swift` |
+| `Tests/ObjC/VTE004_NamedKeyBakupTests.m` | `Tests/Swift/VTE004_NamedKeyBackupTests.swift` |
+
+The original ObjC files are **retained** in `Tests/ObjC/` for reference but are
+no longer executed. They can be deleted in a future cleanup commit.
+
+## API mapping
+
+| ObjC (completion-callback) | Swift (GenericOperation) |
+|---------------------------|--------------------------|
+| `registerWithCompletion:` | `register().startSync().get()` |
+| `register(with:completion:)` | `register(with:).startSync().get()` |
+| `rotatePrivateKeyWithCompletion:` | `rotatePrivateKey().startSync().get()` |
+| `unregisterWithCompletion:` | `unregister().startSync().get()` |
+| `cleanUpAndReturnError:` | `cleanUp()` (throws directly) |
+| `findUserWith:forceReload:completion:` | `findUser(with:forceReload:).startSync().get()` |
+| `authEncryptText:forUser:` | `authEncrypt(text:for:)` |
+| `authDecryptText:fromUser:` | `authDecrypt(text:from:)` |
+| `authDecryptText:fromUser:date:` | `authDecrypt(text:from:date:)` |
+| `authEncryptText:forUsers:` | `authEncrypt(text:for:)` with `FindUsersResult` |
+| `authEncryptData:forUser:` | `authEncrypt(data:for:)` |
+| `authEncryptStream:withSize:toStream:forUsers:` | `authEncrypt(_:streamSize:to:for:)` |
+| `authDecrypt:to:from:` | `authDecrypt(_:to:from:)` |
+| `lookupPublicKeysOf:completion:` (deprecated) | `lookupPublicKeys(of:).startSync().get()` |
+| `encryptWithText:for:` (deprecated) | `encrypt(text:for:)` with `LookupResult` |
+| `decryptWithText:from:` (deprecated) | `decrypt(text:from:)` with `VirgilPublicKey` |
+| `encryptText:forUser:` (deprecated) | `encrypt(text:for:)` with `Card` |
+| `decryptText:fromUser:` (deprecated) | `decrypt(text:from:)` with `Card` |
+| `backupPrivateKeyWithPassword:` | `backupPrivateKey(password:).startSync().get()` |
+| `backupPrivateKeyWithPassword:keyName:` | `backupPrivateKey(password:keyName:).startSync().get()` |
+| `restorePrivateKeyWithPassword:` | `restorePrivateKey(password:).startSync().get()` |
+| `restorePrivateKeyWithPassword:keyName:` | `restorePrivateKey(password:keyName:).startSync().get()` |
+| `changePasswordFrom:to:` | `changePassword(from:to:).startSync().get()` |
+| `changePasswordFrom:to:keyName:` | `changePassword(from:to:keyName:).startSync().get()` |
+| `resetPrivateKeyBackupWithPassword:` (deprecated) | `resetPrivateKeyBackup(password:).startSync().get()` |
+| `resetPrivateKeyBackupWithCompletion:` | `resetPrivateKeyBackup().startSync().get()` |
+| `resetPrivateKeyBackupWithKeyName:` | `resetPrivateKeyBackup(keyName:).startSync().get()` |
+| `+derivePasswordsFrom:error:` | `EThree.derivePasswords(from:)` (static, throws) |
+| `cardManager.searchCardsWithIdentities:completion:` | `cardManager.searchCards(identities:).startSync().get()` |
+
+## VTE003 (key backup) — adaptation notes
+
+The ObjC `VTE003_KeyBackupTests` set up cloud backups using the low-level
+`TestUtils.setUpSyncKeyStorageWithPassword:` helper (callback-based, wraps
+Keyknox directly). The Swift migration replaces this setup with the high-level
+EThree API round-trip:
+
+1. `register()` — creates the local private key
+2. `backupPrivateKey(password:)` — pushes backup to Keyknox via brainkey v2
+3. `cleanUp()` — removes the local private key
+4. `restorePrivateKey(password:)` — retrieves and decrypts from Keyknox via brainkey v2
+
+This approach directly exercises `BrainkeyHttpClient.harden` and
+`CloudKeyManager.deriveKeyPair` which were previously untested in the SPM target.
+
+The ObjC `test04_STE_18` ("reset with password") tested the deprecated
+`resetPrivateKeyBackupWithPassword:` path. The Swift equivalent (`test05_STE_19`)
+covers the same deprecated path; `test04_STE_18` covers the modern
+`resetPrivateKeyBackup()` which uses `keyknoxManager.resetValue()`.
+
+## Brainkey integration coverage
+
+Before this migration, `BrainkeyHttpClient.harden` was only covered by ObjC tests
+that were excluded from SPM/CI. After this migration, every CI run exercises the
+full brainkey v2 round-trip:
+
+```
+BrainkeyClient.blind(password)
+  → POST api.virgilsecurity.com/brainkey
+  → BrainkeyClient.deblind(...)
+  → crypto.generateKeyPair(ofType: .curve25519, usingSeed:)
+  → Keyknox store/retrieve
+```

--- a/docs/test-migration-objc-to-swift.md
+++ b/docs/test-migration-objc-to-swift.md
@@ -76,16 +76,24 @@ The ObjC `test04_STE_18` ("reset with password") tested the deprecated
 covers the same deprecated path; `test04_STE_18` covers the modern
 `resetPrivateKeyBackup()` which uses `keyknoxManager.resetValue()`.
 
-## Brainkey integration coverage
+## Key derivation: SHA-512 (local)
 
-Before this migration, `BrainkeyHttpClient.harden` was only covered by ObjC tests
-that were excluded from SPM/CI. After this migration, every CI run exercises the
-full brainkey v2 round-trip:
+`CloudKeyManager.deriveKeyPair` currently uses a local SHA-512 hash of
+`"e3kit-backup\0<identity>\0<password>"` as the key seed. This is the approach
+used before pythia was removed from `virgil-crypto-c 0.19.x`.
 
+The `virgil-services-brainkey` v2 service (OPRF-based hardening) exists and
+`BrainkeyHttpClient` is implemented, but the service is not yet deployed on the
+API gateway — `POST https://api.virgilsecurity.com/brainkey` returns HTTP 404.
+Until it is deployed and the config updated, the SHA-512 local derivation is used.
+
+Every CI run exercises the full backup/restore lifecycle:
 ```
-BrainkeyClient.blind(password)
-  → POST api.virgilsecurity.com/brainkey
-  → BrainkeyClient.deblind(...)
+crypto.computeHash("e3kit-backup\0<identity>\0<password>", sha512)
   → crypto.generateKeyPair(ofType: .curve25519, usingSeed:)
   → Keyknox store/retrieve
 ```
+
+When the brainkey service is deployed, re-enable `BrainkeyHttpClient.harden`
+in `CloudKeyManager.deriveKeyPair` and update `TestUtils.setUpSyncKeyStorage`
+to match.


### PR DESCRIPTION
## Summary

- Ports `VTE001_PeerToPeerTests`, `VTE002_AuthenticationTests`, `VTE003_KeyBackupTests`, and `VTE004_NamedKeyBackupTests` from ObjC to Swift so they run in the SPM test target and CI
- Adds brainkey v2 integration coverage: `VTE003`/`VTE004` now exercise `BrainkeyHttpClient.harden → CloudKeyManager.deriveKeyPair → Keyknox` on every CI run
- Adds `docs/test-migration-objc-to-swift.md` documenting the API mapping and adaptation rationale
- Original ObjC files retained in `Tests/ObjC/` for reference

## Test plan

- [ ] CI passes (all new tests green including VTE001–VTE004 brainkey round-trips)
- [ ] No existing tests regressed
- [ ] Build compiles with zero errors and zero non-deprecation warnings