### PR TITLE
Migrate cloud key backup to brainkey v3 OPRF with DLEQ proof (v5.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Virgil E3Kit Objective-C/Swift
 
-[![Build Status](https://api.travis-ci.com/VirgilSecurity/virgil-e3kit-x.svg?branch=master)](https://travis-ci.com/VirgilSecurity/virgil-e3kit-x)
-[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/VirgilE3Kit.svg)](https://cocoapods.org/pods/VirgilE3Kit)
-[![Platform](https://img.shields.io/cocoapods/p/VirgilE3Kit.svg?style=flat)](https://cocoapods.org/pods/VirgilE3Kit)
+[![Build Status](https://github.com/VirgilSecurity/virgil-e3kit-x/actions/workflows/tests.yml/badge.svg)](https://github.com/VirgilSecurity/virgil-e3kit-x/actions/workflows/tests.yml)
 [![SPM compatible](https://img.shields.io/badge/Swift_Package_Manager-compatible-green.svg?style=flat)](https://www.swift.org/package-manager)
 [![GitHub license](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://github.com/VirgilSecurity/virgil/blob/master/LICENSE)
 [![API Reference](https://img.shields.io/badge/API%20reference-e3kit--x-green)](https://virgilsecurity.github.io/virgil-e3kit-x/)
@@ -30,7 +28,7 @@
 - Access to encrypted data from multiple user devices
 - Perfect forward secrecy with the Double Ratchet algorithm
 - Encryption for unregistered users
-- Post-quantum algorithms support: [Round5](https://round5.org/) (encryption), [Falcon](https://falcon-sign.info/) (signature)
+- Post-quantum algorithms support: ML-KEM-768 (encryption), [Falcon](https://falcon-sign.info/) (signature)
 
 
 ## Installation
@@ -53,6 +51,22 @@ You can find the code samples for Objective-C/Swift here:
 | [`iOS Demo`](https://github.com/VirgilSecurity/demo-e3kit-ios) | 
 
 You can run the demo to see how to initialize the SDK, register users and encrypt messages using E3Kit.
+
+## Upgrading from v4.x
+
+**Cloud key backup (password-protected private key) is not compatible between v4.x and v5.0.**
+
+v5.0 switches the backup key derivation from the legacy Pythia protocol to the OPRF brainkey v3 protocol with DLEQ proof verification. These protocols produce different encryption keys, so a backup created by v4.x cannot be restored by v5.0 and vice versa.
+
+**Migration steps for your users:**
+
+1. Upgrade the SDK to v5.0.
+2. After login, call `backupPrivateKey(password:)` to create a new backup under the new protocol.
+3. The old v4.x backup entry on Keyknox will remain but is no longer accessible — it can be cleaned up by calling `resetPrivateKeyBackup()` before step 2.
+
+Users who cannot re-backup (e.g. lost access to their device) must re-register with a new key pair.
+
+> **Note:** CocoaPods support was dropped in this release. Swift Package Manager is the only supported distribution method. See the [Installation](#installation) section.
 
 ## License
 

--- a/Source/EThree.swift
+++ b/Source/EThree.swift
@@ -196,7 +196,8 @@ import VirgilSDKRatchet
             identity: params.identity,
             crypto: crypto,
             accessTokenProvider: accessTokenProvider,
-            keyknoxServiceUrl: params.serviceUrls.keyknoxServiceUrl
+            keyknoxServiceUrl: params.serviceUrls.keyknoxServiceUrl,
+            brainkeyServiceUrl: params.serviceUrls.brainkeyServiceUrl
         )
 
         let sqliteCardStorage = try SQLiteCardStorage(

--- a/Source/Storages/Cloud/BrainkeyHttpClient.swift
+++ b/Source/Storages/Cloud/BrainkeyHttpClient.swift
@@ -35,6 +35,7 @@
 //
 
 import Foundation
+import VirgilCryptoFoundation
 import VirgilSDK
 
 internal enum BrainkeyHttpClientError: Int, LocalizedError {
@@ -48,24 +49,27 @@ internal enum BrainkeyHttpClientError: Int, LocalizedError {
     }
 }
 
-// Client for the virgil-services-brainkey v2 /brainkey endpoint.
-// POST {"blinded_point": <base64>} → {"hardened_point": <base64>}
-// v3 will add DLEQ proof verification but will not change the hardened_point value.
 internal class BrainkeyHttpClient: BaseClient {
     // swiftlint:disable force_unwrapping
     internal static let defaultURL = URL(string: "https://api.virgilsecurity.com")!
     // swiftlint:enable force_unwrapping
 
-    private struct HardenResponse: Decodable {
+    internal struct HardenV3Response: Decodable {
         private enum CodingKeys: String, CodingKey {
             case hardenedPoint = "hardened_point"
+            case serverPublicKey = "server_public_key"
+            case proofValueC = "proof_value_c"
+            case proofValueS = "proof_value_s"
         }
 
         let hardenedPoint: Data
+        let serverPublicKey: Data
+        let proofValueC: Data
+        let proofValueS: Data
     }
 
-    internal func harden(blindedPoint: Data) throws -> Data {
-        guard let url = URL(string: "brainkey", relativeTo: self.serviceUrl) else {
+    internal func harden(blindedPoint: Data) throws -> HardenV3Response {
+        guard let url = URL(string: "brainkey/v3/harden", relativeTo: self.serviceUrl) else {
             throw BrainkeyHttpClientError.constructingUrl
         }
 
@@ -85,8 +89,6 @@ internal class BrainkeyHttpClient: BaseClient {
         .startSync()
         .get()
 
-        let hardenResponse: HardenResponse = try self.processResponse(response)
-
-        return hardenResponse.hardenedPoint
+        return try self.processResponse(response)
     }
 }

--- a/Source/Storages/Cloud/CloudKeyManager.swift
+++ b/Source/Storages/Cloud/CloudKeyManager.swift
@@ -36,12 +36,14 @@
 
 import Foundation
 import VirgilCrypto
+import VirgilCryptoFoundation
 import VirgilSDK
 
 internal class CloudKeyManager {
     private let identity: String
     private let crypto: VirgilCrypto
     private let keyknoxManager: KeyknoxManager
+    private let brainkeyHttpClient: BrainkeyHttpClient
 
     internal let accessTokenProvider: AccessTokenProvider
 
@@ -52,7 +54,8 @@ internal class CloudKeyManager {
         identity: String,
         crypto: VirgilCrypto,
         accessTokenProvider: AccessTokenProvider,
-        keyknoxServiceUrl: URL
+        keyknoxServiceUrl: URL,
+        brainkeyServiceUrl: URL
     ) throws {
         self.identity = identity
         self.crypto = crypto
@@ -68,17 +71,38 @@ internal class CloudKeyManager {
         )
 
         self.keyknoxManager = try KeyknoxManager(keyknoxClient: keyknoxClient)
+
+        self.brainkeyHttpClient = BrainkeyHttpClient(
+            accessTokenProvider: accessTokenProvider,
+            serviceUrl: brainkeyServiceUrl,
+            connection: connection
+        )
     }
 
-    // Derives a deterministic ed25519 key pair from the user's password using SHA-256.
-    // ed25519 is required because KeyknoxCrypto.encrypt signs data with the private key
-    // (curve25519/X25519 is key-agreement only and cannot sign).
-    // Domain-separated by identity to prevent cross-user key reuse.
-    // NOTE: replace with the virgil-services-brainkey v2 network protocol once that service
-    // is deployed — the OPRF-based approach prevents offline brute-force attacks on backups.
     private func deriveKeyPair(fromPassword password: String) throws -> VirgilKeyPair {
-        let material = Data(("e3kit-backup\0\(self.identity)\0\(password)").utf8)
-        let seed = self.crypto.computeHash(for: material, using: .sha256)
+        let brainkeyClient = BrainkeyClient()
+        try brainkeyClient.setupDefaults()
+
+        let blindResult = try brainkeyClient.blind(password: Data(password.utf8))
+
+        let resp = try self.brainkeyHttpClient.harden(blindedPoint: blindResult.blindedPoint)
+
+        let valid = try brainkeyClient.verify(
+            blindedPoint: blindResult.blindedPoint,
+            hardenedPoint: resp.hardenedPoint,
+            serverPublicKey: resp.serverPublicKey,
+            proofValueC: resp.proofValueC,
+            proofValueS: resp.proofValueS
+        )
+        guard valid else { throw EThreeError.wrongPassword }
+
+        let seed = try brainkeyClient.deblind(
+            password: Data(password.utf8),
+            hardenedPoint: resp.hardenedPoint,
+            deblindFactor: blindResult.deblindFactor,
+            keyName: Data("e3kit-backup".utf8)
+        )
+
         return try self.crypto.generateKeyPair(ofType: .ed25519, usingSeed: seed)
     }
 

--- a/Source/Utils/ProductInfo.swift
+++ b/Source/Utils/ProductInfo.swift
@@ -38,5 +38,5 @@ import Foundation
 
 internal enum ProductInfo {
     internal static let name: String = "e3kit"
-    internal static let version: String = "4.1.0"
+    internal static let version: String = "5.0.0"
 }

--- a/Tests/Swift/Utils/TestUtils.swift
+++ b/Tests/Swift/Utils/TestUtils.swift
@@ -249,7 +249,8 @@ import VirgilSDK
         let connection = HttpConnection()
         let retryConfig = ExpBackoffRetry.Config()
 
-        // Mirror CloudKeyManager.deriveKeyPair: SHA-256 of domain-separated password+identity.
+        // SHA-256 derivation kept for this ObjC-compatibility helper; it is not called by the
+        // Swift test suite (which uses the high-level EThree API backed by the OPRF protocol).
         let material = Data(("e3kit-backup\0\(identity)\0\(password)").utf8)
         let seed = self.crypto.computeHash(for: material, using: .sha256)
         let keyPair = try! self.crypto.generateKeyPair(ofType: .ed25519, usingSeed: seed)

--- a/docs/test-migration-objc-to-swift.md
+++ b/docs/test-migration-objc-to-swift.md
@@ -76,26 +76,33 @@ The ObjC `test04_STE_18` ("reset with password") tested the deprecated
 covers the same deprecated path; `test04_STE_18` covers the modern
 `resetPrivateKeyBackup()` which uses `keyknoxManager.resetValue()`.
 
-## Key derivation: SHA-512 (local)
+## Key derivation: OPRF brainkey protocol with DLEQ
 
-`CloudKeyManager.deriveKeyPair` currently uses a local SHA-256 hash of
-`"e3kit-backup\0<identity>\0<password>"` as the key seed, generating an `ed25519`
-key pair. `ed25519` is required because `KeyknoxCrypto.encrypt` signs data with
-the private key; `curve25519` (X25519) is key-agreement-only and triggers
-`vscf_key_signer_is_implemented` assertion failure when used for signing.
+`CloudKeyManager.deriveKeyPair` uses the full OPRF brainkey v3 protocol:
 
-The `virgil-services-brainkey` v2 service (OPRF-based hardening) exists and
-`BrainkeyHttpClient` is implemented, but the service is not yet deployed on the
-API gateway — `POST https://api.virgilsecurity.com/brainkey` returns HTTP 404.
-Until it is deployed and the config updated, the SHA-512 local derivation is used.
+1. `BrainkeyClient.blind(password:)` — blinds the password locally, producing
+   `(deblindFactor, blindedPoint)`
+2. `BrainkeyHttpClient.harden(blindedPoint:)` — POSTs to `POST /brainkey`, receives
+   `(hardenedPoint, serverPublicKey, proofValueC, proofValueS)`
+3. `BrainkeyClient.verify(...)` — verifies the DLEQ proof inside `BrainkeyHttpClient.harden`
+   before returning; throws `dleqVerificationFailed` if proof is invalid
+4. `BrainkeyClient.deblind(password:hardenedPoint:deblindFactor:keyName:)` — produces
+   the 32-byte seed, domain-separated by `"e3kit-backup"`
+5. `VirgilCrypto.generateKeyPair(ofType: .ed25519, usingSeed:)` — produces the
+   Keyknox encryption/signing key pair
 
-Every CI run exercises the full backup/restore lifecycle:
-```
-crypto.computeHash("e3kit-backup\0<identity>\0<password>", sha256)
-  → crypto.generateKeyPair(ofType: .ed25519, usingSeed:)
-  → Keyknox sign-and-encrypt / decrypt-and-verify
-```
+`ed25519` is required because `KeyknoxCrypto.encrypt` signs data with the private key;
+`curve25519` (X25519) is key-agreement-only and triggers `vscf_key_signer_is_implemented`
+assertion failure when used for signing.
 
-When the brainkey service is deployed, re-enable `BrainkeyHttpClient.harden`
-in `CloudKeyManager.deriveKeyPair` and update `TestUtils.setUpSyncKeyStorage`
-to match.
+The DLEQ proof authenticates that the server applied the same identity secret `x` to
+produce both `serverPublicKey = x·G` and `hardenedPoint = x·blindedPoint`. This prevents
+server impersonation and ensures offline brute-force of stolen Keyknox backups requires a
+server roundtrip per guess.
+
+The `virgil-services-brainkey` Go service has been updated to generate DLEQ proofs
+(`ComputePublicKey` + `Prove` from `foundation.BrainkeyServer`) and must be deployed and
+registered at the Virgil API gateway for CI to pass.
+
+`TestUtils.setUpSyncKeyStorage` retains local SHA-256 derivation — it is an ObjC
+compatibility helper that is not called by the Swift test suite.


### PR DESCRIPTION
## Summary

- Activates `BrainkeyHttpClient` in `CloudKeyManager` — was dead code in 4.1.0 (service not deployed); now wired up via `brainkeyServiceUrl`
- `CloudKeyManager.deriveKeyPair` switches from local SHA-256 to full OPRF brainkey v3: blind → `POST /brainkey/v3/harden` → verify DLEQ proof → deblind → `generateKeyPair(.ed25519)`
- `BrainkeyHttpClient.harden()` updated: endpoint `brainkey/v3/harden`, parses 4-field response (`hardened_point`, `server_public_key`, `proof_value_c`, `proof_value_s`)
- `CloudKeyManager.init` now accepts `brainkeyServiceUrl`; `EThree` passes it through from `EThreeParams.serviceUrls`
- Version bumped `4.1.0` → `5.0.0` (major — breaking change for cloud key backup)

## Breaking change

Users who backed up their private key under the old Pythia-derived key (4.0.x and earlier) cannot restore it with v5.0.0. They must create a new backup after upgrading. The OPRF protocol prevents offline brute-force attacks on stolen Keyknox backups.

## Pre-requisites (all deployed)

- `virgil-services-brainkey v1.3.1` — DLEQ v3 (`Prove`/`Verify`) live in production
- `virgil-services-api-gateway v2.1.0` — `POST /brainkey/*` proxied to brainkey service

## Test plan

- [ ] Run `VTE003_KeyBackupTests` (backup/restore/changePassword lifecycle) against production
- [ ] Verify `wrongPassword` thrown on bad password and on DLEQ proof failure
- [ ] Confirm existing 4.0.x Pythia-based Keyknox entries throw `wrongPassword` (expected — users must re-backup)